### PR TITLE
Remove duplicated local storage setup call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,10 +35,6 @@ function setupTestEnv( markup, features ) {
 	if ( features.XMLHttpRequest ) {
 		global.XMLHttpRequest = window.XMLHttpRequest;
 	}
-
-	if ( features.localStorage ) {
-		require( './local-storage' )( global );
-	}
 }
 
 function cleanup() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-env",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React Test Environment Setup",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,8 @@
     "jsdom": "9.4.1",
     "lodash.assign": "4.1.0"
   },
-  "peerDependencies": {
-    "react": ">=0.14.8"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.4.5",
-    "react-dom": "0.14.8"
+    "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
It should work as before. It just removes duplicated local storage polyfill setup call.
### Testing

Run `npm test`. All tests should pass.
