### PR TITLE
Add `global.Image`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ function setupTestEnv( markup, features ) {
 	global.navigator = window.navigator;
 	global.Element = window.Element;
 	global.history = window.history;
+	global.Image = window.Image;
 
 	if ( features.localStorage ) {
 		require( './local-storage' )( global );
@@ -43,6 +44,7 @@ function cleanup() {
 	delete global.navigator;
 	delete global.Element;
 	delete global.history;
+	delete global.Image;
 	if ( global.localStorage ) {
 		if ( global.localStorage.clear ) {
 			global.localStorage.clear();


### PR DESCRIPTION
This pull request addresses #6 by copying `window.Image` to `global.Image`, allowing the use of `new Image()`.